### PR TITLE
Add the `visualstudio2017-workload-vctools` package

### DIFF
--- a/Dockerfile.win32
+++ b/Dockerfile.win32
@@ -22,6 +22,7 @@ RUN choco install -y cmake --installargs 'ADD_CMAKE_TO_PATH=System'
 
 RUN choco install -y visualstudio2017community
 RUN choco install -y visualstudio2017-workload-nativedesktop
+RUN choco install -y visualstudio2017-workload-vctools 
 
 RUN setx /M PATH "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Tools\MSVC\14.16.27023\bin\HostX86\x86;%PATH%"
 


### PR DESCRIPTION
This is intended to solve the build issue on our `dist-x86_64-msvc` builder ([example](https://dev.azure.com/rust-lang/rust/_build/results?buildId=4733)) where the ARM64 compiler for Windows doesn't appear to be installed. According to [this page](https://chocolatey.org/packages/visualstudio2017-workload-vctools) the workload components installed here are [these](https://docs.microsoft.com/en-us/visualstudio/install/workload-component-id-vs-build-tools?view=vs-2017#visual-c-build-tools) which includes `Microsoft.VisualStudio.Component.VC.Tools.ARM64` which I think does the trick. I'm not certain this works but I figured it's worth a shot.